### PR TITLE
Manage threads concurrent access: add user Rating Verrous

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </repositories>
 	
     <dependencies>
-	<dependency>
+		<dependency>
             <groupId>fr.paris.lutece</groupId>
             <artifactId>lutece-core</artifactId>
             <version>[7.0.6,)</version>

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/facade/RatingFacadeFactory.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/facade/RatingFacadeFactory.java
@@ -65,7 +65,8 @@ public class  RatingFacadeFactory {
             {
                 _listRatingType.stream( ).filter( rat -> rat.getType( ).equals( rating.getClass( ) ) ).findAny( ).orElseThrow( RatingTypeException::new ).doRating( rating );
                 _ratingSecurityService.freeAccess( rating.getUser( ) );
-            } else
+            } 
+            else
             {
                 throw new RatingException( I18nService.getLocalizedString( RatingConstants.MESSAGE_CANNOT_VOTE, LocaleService.getDefault( ) ) );
             }

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/facade/RatingFacadeFactory.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/facade/RatingFacadeFactory.java
@@ -61,8 +61,14 @@ public class  RatingFacadeFactory {
 	        {
 	        	throw new RatingException( I18nService.getLocalizedString(RatingConstants.MESSAGE_CANNOT_VOTE, LocaleService.getDefault( ) ));
 	        }
-		   _listRatingType.stream().filter( rat ->  rat.getType( ).equals( rating.getClass( ) ) )
-				.findAny().orElseThrow( RatingTypeException::new ).doRating( rating );		
+            if ( _ratingSecurityService.isFreeAccess( rating.getUser( ) ) )
+            {
+                _listRatingType.stream( ).filter( rat -> rat.getType( ).equals( rating.getClass( ) ) ).findAny( ).orElseThrow( RatingTypeException::new ).doRating( rating );
+                _ratingSecurityService.freeAccess( rating.getUser( ) );
+            } else
+            {
+                throw new RatingException( I18nService.getLocalizedString( RatingConstants.MESSAGE_CANNOT_VOTE, LocaleService.getDefault( ) ) );
+            }
 
 	}
 	/**

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/IRatingSecurityService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/IRatingSecurityService.java
@@ -113,9 +113,9 @@ public interface IRatingSecurityService
     boolean hasAlreadyVoted(LuteceUser user, String strIdExtendableResource, String strExtendableResourceType );
     
     /**
-     * true if the user rating is in progress
+     * Check if any user rating process in progress
      * @param Lutece user
-     * @return true if no rating in progress, false if another User rating in progress
+     * @return true if no rating in progress, false if User rating in progress
      */
     boolean isFreeAccess( LuteceUser user );
     

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/IRatingSecurityService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/IRatingSecurityService.java
@@ -112,5 +112,18 @@ public interface IRatingSecurityService
      */
     boolean hasAlreadyVoted(LuteceUser user, String strIdExtendableResource, String strExtendableResourceType );
     
+    /**
+     * true if the user rating is in progress
+     * @param Lutece user
+     * @return true if no rating in progress, false if another User rating in progress
+     */
+    boolean isFreeAccess( LuteceUser user );
+    
+    /**
+     * free the user rating process
+     * @param Lutece user
+     */
+    void freeAccess( LuteceUser user );
+    
     
 }

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/RatingSecurityService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/RatingSecurityService.java
@@ -58,7 +58,9 @@ import org.apache.commons.collections.CollectionUtils;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -73,6 +75,7 @@ public class RatingSecurityService implements IRatingSecurityService
 {
     /** The Constant BEAN_SERVICE. */
     private static final String FILTER_SORT_BY_DATE_VOTE = " date_creation ";
+    private Set<LuteceUser> userRatingVerrous = new HashSet<>( );
     @Inject
     @Named( ResourceExtenderHistoryService.BEAN_SERVICE )
     private IResourceExtenderHistoryService _resourceExtenderHistoryService;  
@@ -309,5 +312,18 @@ public class RatingSecurityService implements IRatingSecurityService
         }
         
         return true;
+    }
+    
+    public boolean isFreeAccess(LuteceUser user) {
+        if (userRatingVerrous.contains(user)) {
+            return false; 
+        } else {
+            userRatingVerrous.add(user);
+            return true;
+        }
+    }
+    
+    public void freeAccess(LuteceUser user) {
+        userRatingVerrous.remove(user);
     }
 }

--- a/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/RatingSecurityService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/rating/service/security/RatingSecurityService.java
@@ -75,7 +75,7 @@ public class RatingSecurityService implements IRatingSecurityService
 {
     /** The Constant BEAN_SERVICE. */
     private static final String FILTER_SORT_BY_DATE_VOTE = " date_creation ";
-    private Set<LuteceUser> userRatingVerrous = new HashSet<>( );
+    private Set<LuteceUser> _userRatingVerrous = new HashSet<>( );
     @Inject
     @Named( ResourceExtenderHistoryService.BEAN_SERVICE )
     private IResourceExtenderHistoryService _resourceExtenderHistoryService;  
@@ -314,16 +314,21 @@ public class RatingSecurityService implements IRatingSecurityService
         return true;
     }
     
-    public boolean isFreeAccess(LuteceUser user) {
-        if (userRatingVerrous.contains(user)) {
+    public boolean isFreeAccess(LuteceUser user)
+    {
+        if (_userRatingVerrous.contains(user)) 
+        {
             return false; 
-        } else {
-            userRatingVerrous.add(user);
+        } 
+        else 
+        {
+            _userRatingVerrous.add(user);
             return true;
         }
     }
     
-    public void freeAccess(LuteceUser user) {
-        userRatingVerrous.remove(user);
+    public void freeAccess(LuteceUser user)
+    {
+        _userRatingVerrous.remove(user);
     }
 }


### PR DESCRIPTION
Bug fixing:  bypass the rating restriction (one vote per user) when sending parallel requests with the same user.
Solution: add a lock to ensure that during a rating in progress, the same user cannot make another rating.